### PR TITLE
Migrate from facility to metro lingo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,11 +78,12 @@
 
             config = lib.mkOption {
               type = lib.types.submodule {
-                options.facilities = lib.mkOption {
-                  type = with lib.types; listOf str;
+                options.metro = lib.mkOption {
+                  type = lib.types.str;
                   description = lib.mdDoc ''
-                    The facilities the instances are allowed to be created in.
+                    Metro code or ID of where the instance should be provisioned in.
                   '';
+                  example = "any";
                 };
                 options.tags = lib.mkOption {
                   type = with lib.types; listOf str;

--- a/src/device.rs
+++ b/src/device.rs
@@ -46,7 +46,7 @@ pub struct Device {
 #[derive(Serialize, Debug)]
 struct CreateDeviceRequest {
     always_pxe: bool,
-    facility: Vec<String>,
+    metro: String,
     hostname: String,
     ipxe_script_url: String,
     operating_system: String,
@@ -62,7 +62,7 @@ pub async fn create_device(
     equinix_project_id: &str,
     plan: HardwarePlan,
     tags: &[String],
-    facilities: &[String],
+    metro: &str,
 ) -> Result<Device> {
     let raw = http_client
         .post(format!(
@@ -78,7 +78,7 @@ pub async fn create_device(
             spot_instance: true,
             spot_price_max: plan.bid,
             tags: tags.to_vec(),
-            facility: facilities.to_vec(),
+            metro: metro.into(),
         })
         .header(ACCEPT, "application/json")
         .header(CONTENT_TYPE, "application/json")

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -40,13 +40,13 @@ type CategoryMap = HashMap<System, HashMap<JobSize, HardwareCategory>>;
 pub struct Config {
     categories: CategoryMap,
     tags: Vec<String>,
-    facilities: Vec<String>,
+    metro: String,
 }
 
 pub struct DesiredHardwareConfig {
     pub plans: Vec<HardwarePlan>,
     pub tags: Vec<String>,
-    pub facilities: Vec<String>,
+    pub metro: String,
 }
 
 pub fn parse_config_file(file: &Path) -> Result<Config> {
@@ -119,12 +119,10 @@ pub async fn get_desired_hardware(
 
     let mut tags = config.tags;
     tags.dedup();
-    let mut facilities = config.facilities;
-    facilities.dedup();
 
     Ok(DesiredHardwareConfig {
         plans: desired_hardware,
         tags,
-        facilities,
+        metro: config.metro,
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ struct Cli {
     prometheus_root: String,
 
     /// A JSON description of machines and their Nix system types and job sizes, and the tags and
-    /// facilities with which to create the machines.
+    /// metro with which to create the machines.
     #[clap(long, required = true)]
     config_file: PathBuf,
 }
@@ -111,7 +111,7 @@ async fn real_main(
             &equinix_project_id,
             desired.clone(),
             &desired_hardware.tags,
-            &desired_hardware.facilities,
+            &desired_hardware.metro,
         )
         .await?;
     }


### PR DESCRIPTION
The Equinix Metal API has deprecated¹ use of the facility² keyword back in 2023-05 and now after 2024-03-31 it will be removed.

It has been replaced by the metro³ keyword, that serves a same purpose.

The `"any"` metro can be used to set no restriction on instance creation.

[1] https://feedback.equinixmetal.com/changelog/bye-facilities-hello-again-metros
[2] https://deploy.equinix.com/developers/docs/metal/locations/facilities/
[3] https://deploy.equinix.com/developers/docs/metal/locations/metros/